### PR TITLE
added support for android 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ description: Take pictures with the device camera.
 #         under the License.
 -->
 
+## About this fork
+
+This fork updates the latest version of the apache cordova-plugin-camera plugin that is used by Mi-Corporation (now Ideagen) as of August 2023, which is version 2.4.1.
+The purpose of the update is to provide support for Android version 33, specifically to utilize the permissions READ_MEDIA_IMAGE and READ_MEDIA_VIDEO in place of
+READ_EXTERNAL_STORAGE. This change is required by Android version 33 as documented here: https://developer.android.com/about/versions/13/behavior-changes-13.
+
+Because Mi-Corporation (now Ideagen) still targets cordova-android version 8.0.0, it is not possible to reference the latest version of apache cordova-plugin-camera.
+Instead we will apply the necessary update to version 2.4.1 of cordova-plugin-camera in order to support Android version 33.
+
+The changes applied to support Android version 33 are based on PR #844 in the apache cordova-plugin-camera github repository
+https://github.com/apache/cordova-plugin-camera/pull/844
+
+
 |Android 4.4|Android 5.1|Android 6.0|iOS 9.3|iOS 10.0|Windows 10 Store|Travis CI|
 |:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 |[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=android-4.4,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=android-4.4,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=android-5.1,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=android-5.1,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=android-6.0,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=android-6.0,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=ios-9.3,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=ios-9.3,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=ios-10.0,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=ios-10.0,PLUGIN=cordova-plugin-camera/)|[![Build Status](http://cordova-ci.cloudapp.net:8080/buildStatus/icon?job=cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera)](http://cordova-ci.cloudapp.net:8080/job/cordova-periodic-build/PLATFORM=windows-10-store,PLUGIN=cordova-plugin-camera/)|[![Build Status](https://travis-ci.org/apache/cordova-plugin-camera.svg?branch=master)](https://travis-ci.org/apache/cordova-plugin-camera)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ description: Take pictures with the device camera.
 ## About this fork
 
 This fork updates the latest version of the apache cordova-plugin-camera plugin that is used by Mi-Corporation (now Ideagen) as of August 2023, which is version 2.4.1.
-The purpose of the update is to provide support for Android version 33, specifically to utilize the permissions READ_MEDIA_IMAGE and READ_MEDIA_VIDEO in place of
-READ_EXTERNAL_STORAGE. This change is required by Android version 33 as documented here: https://developer.android.com/about/versions/13/behavior-changes-13.
+The purpose of the update is to provide support for Android version 33, specifically to utilize the permission READ_MEDIA_IMAGE in place of READ_EXTERNAL_STORAGE.
+This change is required by Android version 33 as documented here: https://developer.android.com/about/versions/13/behavior-changes-13.
 
 Because Mi-Corporation (now Ideagen) still targets cordova-android version 8.0.0, it is not possible to reference the latest version of apache cordova-plugin-camera.
 Instead we will apply the necessary update to version 2.4.1 of cordova-plugin-camera in order to support Android version 33.

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,7 +69,6 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera"
-    version="2.4.1">
+    version="2.4.1-dev">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>
@@ -68,6 +68,8 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 
 import org.apache.cordova.BuildHelper;
@@ -40,6 +41,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -100,6 +102,17 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     //Where did this come from?
     private static final int CROP_CAMERA = 100;
 
+
+    /*
+     * Since Mi-Corporation uses cordova-android version 8.0.0 which only supports up to version 28
+     * of the Android SDK, we must manually declare the new Manifest.permission constant values that were
+     * introduced later as well as the latest build constant.
+    */
+    private static final String MANIFEST_PERMISSION_READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
+    private static final String MANIFEST_PERMISSION_READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
+    private static final int BUILD_VERSION_CODES_TIRAMISU = 33;
+
+
     private int mQuality;                   // Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
     private int targetWidth;                // desired width of the image
     private int targetHeight;               // desired height of the image
@@ -112,8 +125,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean correctOrientation;     // Should the pictures orientation be corrected
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
-
-    protected final static String[] permissions = { Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE };
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -185,8 +196,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 }
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
-                    if(!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-                        PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+                    String[] permissions = getPermissions(true, mediaType);
+                    if(!hasPermissions(permissions)) {
+                        PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, permissions);
                     } else {
                         this.getImage(this.srcType, destType, encodingType);
                     }
@@ -212,6 +224,38 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     //--------------------------------------------------------------------------
     // LOCAL METHODS
     //--------------------------------------------------------------------------
+
+   private String[] getPermissions(boolean storageOnly, int mediaType) {
+        ArrayList<String> permissions = new ArrayList<>();
+
+        if (android.os.Build.VERSION.SDK_INT >= BUILD_VERSION_CODES_TIRAMISU) {
+            // Android API 33 and higher
+            switch (mediaType) {
+                case PICTURE:
+                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_IMAGES);
+                    break;
+                case VIDEO:
+                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_VIDEO);
+                    break;
+                default:
+                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_IMAGES);
+                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_VIDEO);
+                    break;
+            }
+        } else {
+            // Android API 32 or lower
+            permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+            permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
+
+        if (!storageOnly) {
+            // Add camera permission when not storage.
+            permissions.add(Manifest.permission.CAMERA);
+        }
+
+        return permissions.toArray(new String[0]);
+    }
+
 
     private String getTempDirectoryPath() {
         File cache = null;
@@ -245,7 +289,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param encodingType           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      */
     public void callTakePicture(int returnType, int encodingType) {
-        boolean saveAlbumPermission = PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
+        String[] storagePermissions = getPermissions(true, mediaType);
+        boolean saveAlbumPermission;
+        if (this.saveToPhotoAlbum) {
+            saveAlbumPermission = hasPermissions(storagePermissions);
+        } else {
+            saveAlbumPermission = true;
+        }
+
         boolean takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA);
 
         // CB-10120: The CAMERA permission does not need to be requested unless it is declared
@@ -276,9 +327,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         } else if (saveAlbumPermission && !takePicturePermission) {
             PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.CAMERA);
         } else if (!saveAlbumPermission && takePicturePermission) {
-            PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+            PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, storagePermissions);
         } else {
-            PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions);
+            PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, getPermissions(false, mediaType));
         }
     }
 
@@ -1219,6 +1270,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         // delete the duplicate file if the difference is 2 for file URI or 1 for Data URL
         if ((currentNumOfImages - numPics) == diff) {
             cursor.moveToLast();
+            @SuppressLint("Range")
             int id = Integer.valueOf(cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media._ID)));
             if (diff == 2) {
                 id--;
@@ -1372,6 +1424,15 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 
         this.callbackContext = callbackContext;
+    }
+
+    private boolean hasPermissions(String[] permissions) {
+        for (String permission: permissions) {
+            if (!PermissionHelper.hasPermission(this, permission)) {
+                return false;
+            }
+        }
+        return true;
     }
 
  /*

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -109,7 +109,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * introduced later as well as the latest build constant.
     */
     private static final String MANIFEST_PERMISSION_READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
-    private static final String MANIFEST_PERMISSION_READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
     private static final int BUILD_VERSION_CODES_TIRAMISU = 33;
 
 
@@ -230,18 +229,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         if (android.os.Build.VERSION.SDK_INT >= BUILD_VERSION_CODES_TIRAMISU) {
             // Android API 33 and higher
-            switch (mediaType) {
-                case PICTURE:
-                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_IMAGES);
-                    break;
-                case VIDEO:
-                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_VIDEO);
-                    break;
-                default:
-                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_IMAGES);
-                    permissions.add(MANIFEST_PERMISSION_READ_MEDIA_VIDEO);
-                    break;
-            }
+            permissions.add(MANIFEST_PERMISSION_READ_MEDIA_IMAGES);
         } else {
             // Android API 32 or lower
             permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);


### PR DESCRIPTION
### Platforms affected
android

### Motivation and Context
Added support for android 13 (API level 33). Note that this mi-corporation version of the Apache plugin is based on version 2.4.1 of the Apache cordova-plugin-camera plugin. I applied the changes necessary to support android 13 in order to support modern android apps.

### Description
For reference I looked at PR #844 in the apache cordova-plugin-camera repository:
https://github.com/apache/cordova-plugin-camera/pull/844

I applied the same changes, namely requesting the permission READ_MEDIA_IMAGES in place of READ_EXTERNAL_DATA. This requirement is documented here:
https://developer.android.com/about/versions/13/behavior-changes-13

### Testing
I placed an updated copy of the corodva-plugin-camera source code on my local file system and updated my config.xml and package.json files to pull cordova-plugin-camera from this local folder rather than from a repote repository.

I built the main cordova app (Ideagen Smartforms) using our android build process, and installed the resulting .apk file into an Android Emulator running version android 13 (API level 33).

I tested Smartforms and confirmed from the Image Annotation field I could load images from the local photo gallery and also take pictures from the camera.

